### PR TITLE
Add release workflow for all branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,18 +2,28 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - '**'
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Generate Version
+        id: version
+        run: |
+          PREFIX="v"
+          YEAR=$(date +'%y')
+          DOY=$(date +'%j')
+          COMMITS=$(git rev-list --count HEAD)
+          VERSION="$PREFIX.$YEAR.$DOY.$COMMITS"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
+          tag_name: ${{ steps.version.outputs.version }}
+          name: Release ${{ github.ref_name }} ${{ steps.version.outputs.version }}
+          target_commitish: ${{ github.sha }}
           draft: false
           prerelease: false

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ brew install --HEAD ./Formula/proxmox-helper-scripts.rb
 
 ## GitHub Actions
 
-Releases are automatically created when tags matching `v*` are pushed. This
-workflow runs for tags created from any branch.
+Releases are automatically created on every push to any branch. Each release
+includes the branch name and uses the version format `v.yy.ddd.N`, where `yy`
+is the two-digit year, `ddd` is the day of the year, and `N` is the commit
+number.
 
 


### PR DESCRIPTION
## Summary
- release on push to any branch
- version releases with prefix, year, day-of-year and commit count
- include branch name in release name
- document new workflow in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c3d2309d883278961af0ee915bccc