### PR TITLE
Fix release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,12 @@
 name: Release
 
 on:
-  pull_request:
+  push:
     branches:
       - '**'
-    types:
-      - closed
 
 jobs:
   create-release:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- run release workflow on any push again

## Testing
- `bash -n misc/generate_release_name.sh`
- `shellcheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c77b0195c8327812a06461af44404